### PR TITLE
Fix calling `ensure=>latest`

### DIFF
--- a/spec/acceptance/installed_to_absent_spec.rb
+++ b/spec/acceptance/installed_to_absent_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper_acceptance'
+
+describe 'installed to ensure absent', :if => (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
+  before(:each) do
+    # Make sure package already removed
+    shell("yum remove -y firefox*", :acceptable_exit_codes => [0,1,2])
+  end
+
+  it 'should run successfully' do
+    pp_first = <<-EOS
+    package{ 'firefox.x86_64':
+      ensure   => '38.0.1-1.el6.centos',
+      provider => yum_arch,
+    }
+    EOS
+
+    apply_manifest(pp_first, :debug => true, :catch_failures => true) do |r|
+      expect(r.stdout).to match(/Detected Arch argument in package! - Moving arch to end of version string/)
+    end
+    apply_manifest(pp_first, :catch_changes => true)
+
+    pp_second = <<-EOS
+    package{ 'firefox.x86_64':
+      ensure   => 'absent',
+      provider => yum_arch,
+    }
+    EOS
+
+    apply_manifest(pp_second, :debug => true, :catch_failures => true)
+    apply_manifest(pp_second, :catch_changes => true)
+  end
+end

--- a/spec/acceptance/installed_to_latest_spec.rb
+++ b/spec/acceptance/installed_to_latest_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper_acceptance'
+
+describe 'previous install to ensure latest', :if => (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
+  before(:each) do
+    # Make sure package already removed
+    shell("yum remove -y firefox*", :acceptable_exit_codes => [0,1,2])
+  end
+
+  it 'should run successfully' do
+    pp_first = <<-EOS
+    package{ 'firefox.x86_64':
+      ensure   => '38.0.1-1.el6.centos',
+      provider => yum_arch,
+    }
+    EOS
+
+    apply_manifest(pp_first, :debug => true, :catch_failures => true) do |r|
+      expect(r.stdout).to match(/Detected Arch argument in package! - Moving arch to end of version string/)
+    end
+    apply_manifest(pp_first, :catch_changes => true)
+
+    pp_second = <<-EOS
+    package{ 'firefox.x86_64':
+      ensure   => 'latest',
+      provider => yum_arch,
+    }
+    EOS
+
+    apply_manifest(pp_second, :debug => true, :catch_failures => true)
+    apply_manifest(pp_second, :catch_changes => true)
+  end
+end

--- a/spec/acceptance/no_install_to_latest_spec.rb
+++ b/spec/acceptance/no_install_to_latest_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'yum_arch example from PUP-1364', :if => (fact('osfamily') == 'RedHat' && (fact('operatingsystemmajrelease') == '6')) do
+describe 'nothing installed to ensure latest works', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
   before(:each) do
     # Make sure package already removed
     shell("yum remove -y firefox*", :acceptable_exit_codes => [0,1,2])
@@ -9,19 +9,17 @@ describe 'yum_arch example from PUP-1364', :if => (fact('osfamily') == 'RedHat' 
   it 'should run successfully' do
     pp = <<-EOS
     package{ 'firefox.x86_64':
-      ensure   => '38.0.1-1.el6.centos',
+      ensure   => 'latest',
       provider => yum_arch,
     }
 
     package{ 'firefox.i686':
-      ensure   => '38.0.1-1.el6.centos',
+      ensure   => 'latest',
       provider => yum_arch,
     }
     EOS
 
-    apply_manifest(pp, :debug => true, :catch_failures => true) do |r|
-      expect(r.stdout).to match(/Detected Arch argument in package! - Moving arch to end of version string/)
-    end
+    apply_manifest(pp, :debug => true, :catch_failures => true)
     apply_manifest(pp, :catch_changes => true)
   end
 end


### PR DESCRIPTION
Currently ensuring latest doesn't work with the module:

``` puppet
Error: Could not get latest version: RPMs must specify a package source
Error: /Stage[main]/Foo::Bar/Foo::Bar[libpng.x86_64]/Package[libpng.x86_64]/ensure: change from 1.2.49-1.el6_2 to latest failed: Could not get latest version: RPMs must specify a package source
```

This pulls the latest changes from Puppet trunk and adds an acceptance test to check
